### PR TITLE
Update Metaphlan and Humann

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,16 @@ This pipeline is based on the original [YAMP](https://github.com/alesssia/YAMP) 
 ```{bash}
 aws batch submit-job \
     --profile maf \
-    --job-name nf-rp-1210-1 \
+    --job-name nf-rp-1101-1 \
     --job-queue priority-maf-pipelines \
     --job-definition nextflow-production \
     --container-overrides command=fischbachlab/nf-reads-profiler,\
 "-r","metaphlan4",\
-"--prefix","paired_end_test",\
+"--prefix","branch_metaphlan4",\
 "--singleEnd","false",\
-"--reads1","s3://czb-seqbot/fastqs/200817_NB501938_0185_AH23FNBGXG/MITI_Purification_Healthy/E8_SH0000236_0619-Cult-2-481_S22_R1_001.fastq.gz",\
-"--reads2","s3://czb-seqbot/fastqs/200817_NB501938_0185_AH23FNBGXG/MITI_Purification_Healthy/E8_SH0000236_0619-Cult-2-481_S22_R2_001.fastq.gz"
-```
-
-### Same account test
-
 "--reads1","s3://dev-scratch/fastq/small/random_ncbi_reads_with_duplicated_and_contaminants_R1.fastq.gz",\
 "--reads2","s3://dev-scratch/fastq/small/random_ncbi_reads_with_duplicated_and_contaminants_R2.fastq.gz"
+```
 
 ### Cross account test
 
@@ -98,3 +93,15 @@ docker container run \
         --download \
         utility_mapping full .
 ```
+
+aws batch submit-job \
+    --profile maf \
+    --job-name nf-rp-1101-1 \
+    --job-queue priority-maf-pipelines \
+    --job-definition nextflow-production \
+    --container-overrides command=fischbachlab/nf-reads-profiler,\
+"-r","metaphlan4",\
+"--prefix","updated_versions",\
+"--singleEnd","false",\
+"--reads1","s3://maf-sequencing/NCBI_SRA/PRJNA612780/SRR11313247_R1.fastq.gz",\
+"--reads2","s3://maf-sequencing/NCBI_SRA/PRJNA612780/SRR11313247_R2.fastq.gz"

--- a/README.md
+++ b/README.md
@@ -84,3 +84,17 @@ docker container run \
 ```
 
 This will create a subdirectory `uniref`, and download and extract the database here.
+
+#### Utility Script Databases
+
+```bash
+cd /mnt/efs/databases/Biobakery/Humann/v3.6
+docker container run \
+    --volume $PWD:$PWD \
+    --workdir $PWD \
+    --rm \
+    458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1 \
+    humann_databases \
+        --download \
+        utility_mapping full .
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This pipeline is based on the original [YAMP](https://github.com/alesssia/YAMP) 
 ```{bash}
 aws batch submit-job \
     --profile maf \
-    --job-name nf-rp-1101-1 \
+    --job-name nf-rp-1101-2 \
     --job-queue priority-maf-pipelines \
     --job-definition nextflow-production \
     --container-overrides command=fischbachlab/nf-reads-profiler,\
@@ -93,15 +93,3 @@ docker container run \
         --download \
         utility_mapping full .
 ```
-
-aws batch submit-job \
-    --profile maf \
-    --job-name nf-rp-1101-1 \
-    --job-queue priority-maf-pipelines \
-    --job-definition nextflow-production \
-    --container-overrides command=fischbachlab/nf-reads-profiler,\
-"-r","metaphlan4",\
-"--prefix","updated_versions",\
-"--singleEnd","false",\
-"--reads1","s3://maf-sequencing/NCBI_SRA/PRJNA612780/SRR11313247_R1.fastq.gz",\
-"--reads2","s3://maf-sequencing/NCBI_SRA/PRJNA612780/SRR11313247_R2.fastq.gz"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ aws batch submit-job \
     --job-name nf-rp-1210-1 \
     --job-queue priority-maf-pipelines \
     --job-definition nextflow-production \
-    --container-overrides command=s3://nextflow-pipelines/nf-reads-profiler,\
+    --container-overrides command=fischbachlab/nf-reads-profiler,\
+"-r","metaphlan4",\
 "--prefix","paired_end_test",\
 "--singleEnd","false",\
 "--reads1","s3://czb-seqbot/fastqs/200817_NB501938_0185_AH23FNBGXG/MITI_Purification_Healthy/E8_SH0000236_0619-Cult-2-481_S22_R1_001.fastq.gz",\
@@ -33,18 +34,19 @@ aws batch submit-job \
 
 Although the databases have been stored at the appropriate `/mnt/efs/databases` location mentioned in the config file. There might come a time when these need to be updated. Here is a quick view on how to do that.
 
-### Metaphlan3
+### Metaphlan4
 
 ```{bash}
-cd /mnt/efs/databases/Biobakery
+cd /mnt/efs/databases/Biobakery/Metaphlan/v4.0
 docker container run \
     --volume $PWD:$PWD \
     --workdir $PWD \
     --rm \
-    biobakery/workflows:3.0.0.a.7 \
+    458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1 \
     metaphlan \
         --install \
-        --bowtie2db metaphlan
+        --nproc 4 \
+        --bowtie2db .
 ```
 
 ### Humann3
@@ -54,12 +56,12 @@ This requires 2 databases.
 #### Chocophlan
 
 ```{bash}
-cd /mnt/efs/databases/Biobakery
+cd /mnt/efs/databases/Biobakery/Humann/v3.6
 docker container run \
     --volume $PWD:$PWD \
     --workdir $PWD \
     --rm \
-    biobakery/workflows:3.0.0.a.7 \
+    458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1 \
         humann_databases \
         --download \
             chocophlan full .
@@ -70,22 +72,15 @@ This will create a subdirectory `chocophlan`, and download and extract the datab
 #### Uniref
 
 ```{bash}
-cd /mnt/efs/databases/Biobakery
+cd /mnt/efs/databases/Biobakery/Humann/v3.6
 docker container run \
     --volume $PWD:$PWD \
     --workdir $PWD \
     --rm \
-    biobakery/workflows:3.0.0.a.7 \
+    458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1 \
         humann_databases \
         --download \
         uniref uniref90_diamond .
 ```
 
 This will create a subdirectory `uniref`, and download and extract the database here.
-
-## Updating the pipeline
-
-```{bash}
-cd nf-reads-profiler
-aws s3 sync --profile maf . s3://nextflow-pipelines/nf-reads-profiler --delete --exclude '.git*' --exclude '*.gz'
-```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,26 @@
+# Updating the image on ECR
+
+## Building and tagging
+
+```bash
+docker build --no-cache -t 458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1 .
+# docker tag biobakery/workflows:maf-20221028-a1 458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1
+```
+
+## Pushing to ECR
+
+```bash
+docker push 458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1
+```
+
+## Troubleshooting
+
+If the push doesn not work. Try the following command on your terminal:
+
+```bash
+sudo yum install -y amazon-efs-utils amazon-ecr-credential-helper
+mkdir ${HOME}/.docker
+echo '{"credsStore": "ecr-login"}' > ${HOME}/.docker/config.json
+```
+
+now retry the push command.

--- a/docker/UPDATES.md
+++ b/docker/UPDATES.md
@@ -1,0 +1,18 @@
+# Change log for Dockerfile
+
+## tag: maf-20221028-a1; latest
+
+[Source](https://github.com/biobakery/biobakery/blob/ed6d4f32fd46af429e1d640cd55f9f4fbcdbede8/docker/workflows/Dockerfile)
+
+Make fewest changes possible to use the latest versions of `Humann` and `Metaphlan`.
+
+- Updated `kneaddata` from version `latest` to `0.12.0`
+- Updated `humann` from version `3.0.0.alpha.3` to `3.6`
+- Updated `phylophlan` from version `0.1.0` to `3.0.3`
+- Updated `numpy` from version `1.14.5` to `1.19.5`
+- Updated `metaphlan` from version `3.0.7` to `4.0.3`
+- Removed step to build the metaphlan database within the container.
+  - required a lot of time and heftier machine to download and index the database.
+  - we install it on EFS separately. Should help with the size of the image.
+- Updated `anadama2` from version `0.7.9` to `0.10.0`
+- Updated `biobakery_workflows` from version `3.0.0-alpha.6` to `3.1`.

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,121 @@
+FROM ubuntu:18.04
+
+# also install python version 2 used by bowtie2
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y python python-dev python3 python3-dev python3-pip apt-transport-https openjdk-8-jre wget zip \
+    python3-matplotlib pandoc texlive software-properties-common \
+    python3-pandas python3-biopython python3-tk && \
+    apt-get remove -y texlive-fonts-recommended-doc texlive-latex-base-doc \
+    texlive-latex-recommended-doc \
+    texlive-pictures-doc texlive-pstricks-doc
+
+RUN pip3 install boto3 cloudpickle awscli
+
+# install dependencies
+# SJ: updated version
+RUN pip3 install kneaddata==0.12.0 --no-binary :all:
+# SJ: updated version
+RUN pip3 install humann==3.6 --no-binary :all:
+# SJ: updated version
+RUN pip3 install numpy==1.19.5
+RUN pip3 install scipy
+RUN pip3 install cython
+RUN apt-get install python3-pysam samtools zlib1g-dev libbz2-dev liblzma-dev -y
+RUN pip3 install biom-format
+
+# install cmseq
+RUN apt-get install -y git && \
+    git clone https://github.com/SegataLab/cmseq.git && \
+    cd cmseq && \
+    python3 setup.py install && \
+    cd ../ && \
+    rm -r cmseq
+
+RUN apt-get install python3-pysam samtools zlib1g-dev libbz2-dev liblzma-dev -y
+
+# install v3 of phylophlan plus dependencies and setup default configuration
+RUN apt-get install fasttree ncbi-blast+ mafft raxml -y
+RUN pip3 install PhyloPhlAn==3.0.3
+RUN wget https://github.com/scapella/trimal/archive/v1.4.1.tar.gz && \
+    tar xzvf v1.4.1.tar.gz && \
+    cd trimal-1.4.1/source/ && make && cp *al /usr/local/bin/ && \
+    cd ../../ && \
+    rm v1.4.1.tar.gz && rm -r trimal-1.4.1
+
+# write config files
+RUN mkdir -p /usr/local/lib/python3.6/dist-packages/phylophlan/phylophlan_configs
+RUN phylophlan_write_config_file -o /usr/local/lib/python3.6/dist-packages/phylophlan/phylophlan_configs/supermatrix_nt.cfg \
+    -d n --db_dna makeblastdb --map_dna blastn --msa mafft --trim trimal --tree1 fasttree --tree2 raxml --overwrite --verbose
+
+RUN pip3 install metaphlan==4.0.3
+# SJ: removed unnecessary because it was installing the database in the container
+# SJ: we install it on EFS separately. Should help with the size of the image
+# RUN metaphlan --install --nproc 24
+
+# install hclust2 from source
+RUN apt-get install -y python-pip python-matplotlib python-scipy python-pandas
+RUN wget https://raw.githubusercontent.com/SegataLab/hclust2/master/hclust2.py && \
+    mv hclust2.py /usr/local/bin/ && \
+    chmod +x /usr/local/bin/hclust2.py
+
+# install R with vegan
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+    add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/' && \
+    apt-get update -y && \
+    apt-get install r-base-dev libcurl4-openssl-dev -y && \
+    R -q -e "install.packages('vegan', repos='http://cran.r-project.org')"
+
+# install workflows 16s dependencies
+RUN wget https://drive5.com/downloads/usearch9.0.2132_i86linux32.gz && \
+    gunzip usearch9.0.2132_i86linux32.gz && \
+    chmod +x usearch9.0.2132_i86linux32 && \
+    mv usearch9.0.2132_i86linux32 /usr/local/bin/usearch
+
+RUN wget https://github.com/torognes/vsearch/releases/download/v2.14.2/vsearch-2.14.2-linux-x86_64.tar.gz && \
+    tar xzvf vsearch-2.14.2-linux-x86_64.tar.gz && \
+    cp vsearch-2.14.2-linux-x86_64/bin/vsearch /usr/local/bin/
+
+# install clustalo and rename fasttree
+RUN apt-get install -y clustalo
+RUN ln -s /usr/bin/fasttree /usr/bin/FastTree
+
+# install picrust2 and dependencies
+RUN apt-get install hmmer -y
+RUN pip3 install pandas --upgrade
+RUN R -q -e "install.packages(c('castor'), repos='http://cran.r-project.org')"
+
+RUN wget https://github.com/picrust/picrust2/archive/v2.3.0-b.tar.gz && tar xvzf v2.3.0-b.tar.gz && ( cd picrust2-2.3.0-b/ && pip3 install --editable . && cp -r picrust2/default_files /usr/local/lib/python3.6/dist-packages/picrust2/) && rm -r picrust2* && rm v2.3.0-b.tar.gz
+
+RUN apt-get install autotools-dev libtool flex bison cmake automake autoconf -y
+
+RUN wget https://github.com/Pbdas/epa-ng/archive/v0.3.6.tar.gz && tar xzvf v0.3.6.tar.gz
+RUN cd epa-ng-0.3.6/ && make && cp bin/epa-ng /usr/local/bin/ && cd ../
+RUN rm -r epa-ng* && rm v0.3.6.tar.gz
+
+RUN wget https://github.com/lczech/gappa/archive/v0.6.0.tar.gz && tar xzvf v0.6.0.tar.gz
+RUN cd gappa-0.6.0/ && make && cp bin/gappa /usr/local/bin/ && cd ../
+RUN rm -r gappa* && rm v0.6.0.tar.gz
+
+# Update to newer pandoc version (to work with latest engine options in anadama2)
+RUN wget https://github.com/jgm/pandoc/releases/download/2.10/pandoc-2.10-1-amd64.deb && \
+    dpkg -i pandoc-2.10-1-amd64.deb && \
+    rm pandoc-2.10-1-amd64.deb
+
+# SJ: updated version
+RUN pip install anadama2==0.10.0
+# SJ: updated version
+RUN pip3 install biobakery_workflows==3.1
+
+# install dada2 and dependencies
+RUN R -q -e "install.packages('BiocManager', repos='http://cran.r-project.org')"
+RUN R -q -e "library(BiocManager); BiocManager::install('dada2')"
+
+RUN R -q -e "install.packages(c('gridExtra','seqinr','castor'), repos='http://cran.r-project.org')"
+
+RUN metaphlan --version && \
+    phylophlan --version && \
+    humann --version
+
+# install picrust1
+RUN wget https://github.com/picrust/picrust/releases/download/v1.1.4/picrust-1.1.4.tar.gz && \
+    tar -xzf picrust-1.1.4.tar.gz && cd picrust-1.1.4 && pip install .

--- a/main.nf
+++ b/main.nf
@@ -291,7 +291,7 @@ process profile_taxa {
 	//Enable multicontainer settings
     container params.docker_container_biobakery
 
-	publishDir "${workingpath}/${params.prefix}/taxa", mode: 'copy', pattern: "*.{biom,tsv}"
+	publishDir "${workingpath}/${params.prefix}/taxa", mode: 'copy', pattern: "*.{biom,tsv,txt}"
 	
 	input:
 	tuple val(name), file(reads) from to_profile_taxa.mix(to_profile_taxa_merged)
@@ -310,13 +310,14 @@ process profile_taxa {
 		--input_type fastq \\
 		--tmp_dir . \\
 		--biom ${name}.biom \\
-		--bowtie2out ${name}_bt2out.txt \\
 		--index ${params.metaphlan_index} \\
 		--bowtie2db ${params.metaphlan_db} \\
+		--bowtie2out ${name}.bowtie2out.txt \\
 		--bt2_ps ${params.bt2options} \\
 		--add_viruses \\
 		--sample_id ${name} \\
 		--nproc ${task.cpus} \\
+		--unclassified_estimation \\
 		$reads \\
 		${name}_metaphlan_bugs_list.tsv 1> profile_taxa_mqc.txt
 	

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,7 +14,7 @@ params {
 
     /* 	Containers
      --------------------------------*/
-    docker_container_biobakery = "biobakery/workflows:3.0.0.a.7"
+    docker_container_biobakery = "458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1"
     docker_container_multiqc = "quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
     docker_container_qiime2 = "qiime2/core:2020.8"
     docker_container_bbmap = "quay.io/biocontainers/bbmap:38.87--h1296035_0"
@@ -42,7 +42,7 @@ params {
    
     //BowTie2 databases for MetaPhlAn
     metaphlan_index="mpa_v30_CHOCOPhlAn_201901"
-    metaphlan_db="/mnt/efs/databases/Biobakery/metaphlan"
+    metaphlan_db="/mnt/efs/databases/Biobakery/Metaphlan/v3.0"
     bt2options="very-sensitive" //presets options for BowTie2
   
     // ChocoPhlAn and UniRef databases for HUMANn analysis

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
   description = 'Metaphlan and HUMANn'
   mainScript = 'main.nf'
   defaultBranch = 'main'
-  version = '0.0.1'
+  version = '0.0.2'
 }
 
 includeConfig "$projectDir/conf/aws_batch.config"
@@ -41,13 +41,13 @@ params {
      --------------------------------*/
    
     //BowTie2 databases for MetaPhlAn
-    metaphlan_index="mpa_v30_CHOCOPhlAn_201901"
-    metaphlan_db="/mnt/efs/databases/Biobakery/Metaphlan/v3.0"
+    metaphlan_index="mpa_vJan21_CHOCOPhlAnSGB_202103"
+    metaphlan_db="/mnt/efs/databases/Biobakery/Metaphlan/v4.0"
     bt2options="very-sensitive" //presets options for BowTie2
   
     // ChocoPhlAn and UniRef databases for HUMANn analysis
-    chocophlan="/mnt/efs/databases/Biobakery/chocophlan"
-    uniref="/mnt/efs/databases/Biobakery/uniref"
+    chocophlan="/mnt/efs/databases/Biobakery/Humann/v3.6/chocophlan"
+    uniref="/mnt/efs/databases/Biobakery/Humann/v3.6/uniref"
 	
   
     /* 	Initialisation

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ params {
     // ChocoPhlAn and UniRef databases for HUMANn analysis
     chocophlan="/mnt/efs/databases/Biobakery/Humann/v3.6/chocophlan"
     uniref="/mnt/efs/databases/Biobakery/Humann/v3.6/uniref"
+    utility_mapping="/mnt/efs/databases/Biobakery/Humann/v3.6/utility_mapping"
 	
   
     /* 	Initialisation


### PR DESCRIPTION
- updated the docker file with updated versions of tools.
  - `458432034220.dkr.ecr.us-west-2.amazonaws.com/biobakery/workflows:maf-20221028-a1`
- updated databases that are required by the new tool versions

## Biobakery dockerfile change log

Make fewest changes possible to use the latest versions of `Humann` and `Metaphlan`.

- Pinned `kneaddata` from version `latest` to `0.12.0`
- Pinned `phylophlan` from version `latest` to `3.0.3`
- Updated `humann` from version `3.0.0.alpha.3` to `3.6`
- Updated `numpy` from version `1.14.5` to `1.19.5`
- Updated `metaphlan` from version `3.0.7` to `4.0.3`
- Updated `anadama2` from version `0.7.9` to `0.10.0`
- Updated `biobakery_workflows` from version `3.0.0-alpha.6` to `3.1`.
- Removed step to package the metaphlan database within the container.